### PR TITLE
Update dev.rb recipe to use https for GitHub clones.

### DIFF
--- a/recipes/dev.rb
+++ b/recipes/dev.rb
@@ -62,7 +62,7 @@ repos.each do |project, options|
   github_name = options.key?(:github_name) ? options[:github_name] : project
 
   git ::File.join(DevHelper.code_root, project) do
-    repository "git://github.com/opscode/#{github_name}"
+    repository "https://github.com/opscode/#{github_name}"
     reference "master"
     action :checkout
   end


### PR DESCRIPTION
HTTPS cloning is nearly as fast as the Git protocol and is able for those behind corporate proxies to easily be manipulated if necessary.