### PR TITLE
[COOK-4371] suggests git instead of depends

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,4 @@ supports 'centos'
 supports 'amazon'
 supports 'ubuntu'
 
-depends 'git'
+suggests 'git'


### PR DESCRIPTION
Using a depends for git makes it difficult to use a bootstrap script to create a new chef-server. Since this is only used in the dev recipe, a suggests seems appropriate.