### PR TITLE
Solves [COOK-4691] - adds ability to use IP address as hostname.

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -66,3 +66,9 @@ suites:
   attributes:
     machine_fqdn: chef.computers.biz
     fqdn_as_hostname: true
+- name: no-fqnd
+  run_list:
+  - recipe[chef-server::default]
+  attributes:
+    chef-server:
+      api_fqdn: ""

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,14 @@ suites:
   run_list:
   - recipe[chef-server]
   attributes: {}
+- name: no-fqnd
+  run_list:
+  - recipe[chef-server]
+  driver:
+    customize:
+      memory: 1024
+    network:
+      - ['private_network', {ip: '192.168.243.2'}]
+  attributes:
+    chef-server:
+      api_fqdn: ""

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The attributes used by this cookbook are under the `chef-server` name space.
 
 Attribute        | Description |Type | Default
 -----------------|-------------|-----|--------
-api_fqdn         | Fully qualified domain name that you want to use for accessing the Web UI and API. | String | node['fqdn']
+api_fqdn         | Fully qualified domain name that you want to use for accessing the Web UI and API. If set to `nil` or empty string (`""`), the IP address will be used as hostname. | String | node['fqdn']
 configuration    | Configuration values to pass down to the underlying server config file (i.e. `/etc/chef-server/chef-server.rb`). | Hash | Hash.new
 package_file     | Location of the Omnibus package to install. This should not be set if you wish to pull the packages from the Omnitruck S3 bucket. | String | nil
 package_checksum | SHA256 checksum of package referenced by `package_file`. | String | nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -98,12 +98,14 @@ execute 'reconfigure-chef-server' do
   action :nothing
 end
 
-ruby_block 'ensure node can resolve API FQDN' do
-  block do
-    fe = Chef::Util::FileEdit.new('/etc/hosts')
-    fe.insert_line_if_no_match(/#{node['chef-server']['api_fqdn']}/,
-      "127.0.0.1 #{node['chef-server']['api_fqdn']}")
-    fe.write_file
+unless node['chef-server']['api_fqdn'].nil? || node['chef-server']['api_fqdn'].empty?
+  ruby_block 'ensure node can resolve API FQDN' do
+    block do
+      fe = Chef::Util::FileEdit.new('/etc/hosts')
+      fe.insert_line_if_no_match(/#{node['chef-server']['api_fqdn']}/,
+        "127.0.0.1 #{node['chef-server']['api_fqdn']}")
+      fe.write_file
+    end
+    not_if { Resolv.getaddress(node['chef-server']['api_fqdn']) rescue false } # host resolves
   end
-  not_if { Resolv.getaddress(node['chef-server']['api_fqdn']) rescue false } # host resolves
 end

--- a/templates/default/chef-server.rb.erb
+++ b/templates/default/chef-server.rb.erb
@@ -2,7 +2,9 @@
 
 topology "standalone"
 
+<% unless node['chef-server']['api_fqdn'].nil? || node['chef-server']['api_fqdn'].empty? -%>
 api_fqdn "<%= node['chef-server']['api_fqdn'] %>"
+<% end -%>
 
 <% node['chef-server']['configuration'].each_pair do |component, tunables| -%>
 <% case tunables -%>


### PR DESCRIPTION
See [COOK-4691 - Capacity to create chef server with IP address as a hostname](https://tickets.opscode.com/browse/COOK-4691).

On top of updating the code, I also updated the README.md files as well as the `.kitchen.yml` file with a suite `name: no-fqnd` and the `.kitchen.cloud.yml` with the same suite to test the changes.

Tested on Ubuntu 12.04 => after a `bundle exec kitchen converge no-fqnd-ubuntu-1204`, you can access the Chef server web UI through `https://192.168.243.2`

I could add a cucumber test that would check that the chef server web page is correctly displayed. Let me know.