### PR TITLE
Stop using deprecated Omnitruck URL

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,7 @@ platforms:
 - name: ubuntu-12.10
 - name: ubuntu-13.04
 - name: ubuntu-13.10
+- name: ubuntu-14.04
 - name: centos-6.5
 - name: centos-5.10
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'kitchen'
 # Style tests. Rubocop and Foodcritic
 namespace :style do
   desc 'Run Ruby style checks'
-  Rubocop::RakeTask.new(:ruby)
+  RuboCop::RakeTask.new(:ruby)
 
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|

--- a/libraries/omnitruck_client.rb
+++ b/libraries/omnitruck_client.rb
@@ -36,11 +36,11 @@ class OmnitruckClient
   end
 
   def package_for_version(version, prerelease = false, nightly = false)
-    url = 'http://www.opscode.com/chef/download-server'
+    url = 'https://www.opscode.com/chef/metadata-server'
     url << "?p=#{platform}"
     url << "&pv=#{platform_version}"
     url << "&m=#{machine_architecture}"
-    url << "&v=#{version}" if version
+    url << "&v=#{version}" if version && version != :latest
     url << "&prerelease=#{prerelease}"
     url << "&nightlies=#{nightly}"
     Chef::Log.info("Omnitruck download-server request: #{url}")
@@ -59,11 +59,8 @@ class OmnitruckClient
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
     response = http.get(url.request_uri, {})
-    case response
-    when Net::HTTPRedirection
-      response['location']
-    else
-      nil
-    end
+    url = response.body.lines.select { |l| l =~ /^url\s/ }.shift
+    url = url.split(/\s/, 2).last.strip
+    return url
   end
 end


### PR DESCRIPTION
Fixes issue #48 by using the Omnitruck `metadata-server` endpoint rather than the deprecated `download-server` endpoint, as suggested in #52.