### PR TITLE
Crude support for chef-server 12

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,8 @@ default['chef-server']['package_file'] = nil
 default['chef-server']['package_checksum'] = nil
 default['chef-server']['package_options'] = nil
 default['chef-server']['api_fqdn'] = node['fqdn']
+default['chef-server']['config_path'] = '/etc/chef-server' # Set to '/etc/opscode' for chef-server 12+
+
 
 #
 # Chef Server Tunables

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,6 +36,7 @@ end
 
 package_name = ::File.basename(omnibus_package)
 package_local_path = "#{Chef::Config[:file_cache_path]}/#{package_name}"
+config_path = node['chef-server']['config_path'] || '/etc/chef-server'
 
 # Ensure :file_cache_path exists
 directory Chef::Config[:file_cache_path] do
@@ -76,7 +77,7 @@ package package_name do # ignore ~FC009 known bug in food critic causes this to 
 end
 
 # create the chef-server etc directory
-directory '/etc/chef-server' do
+directory config_path do
   owner 'root'
   group 'root'
   recursive true
@@ -84,7 +85,7 @@ directory '/etc/chef-server' do
 end
 
 # create the initial chef-server config file
-template '/etc/chef-server/chef-server.rb' do
+template config_path + '/chef-server.rb' do
   source 'chef-server.rb.erb'
   owner 'root'
   group 'root'


### PR DESCRIPTION
Hackish approach to supporting chef server 12 by adding an attribute for the /etc/ path in which to write the chef-server.rb file.

To use to install Chef Server 12, set:

default['chef-server']['package_file'] = '...' # Some chef-server 12 RPM or DEB URL
default['chef-server']['config_path'] = '/etc/opscode'

I don't really expect this to get merged in, as there is surely a better / more official way.  I didn't want to implement logic around the version, since I don't control what :latest means, etc, and someone is surely working on this somewhere.

